### PR TITLE
messageAction should explicitly clearResponse

### DIFF
--- a/src/slapp.js
+++ b/src/slapp.js
@@ -793,7 +793,7 @@ class Slapp extends EventEmitter {
       // Instead you use the response_url to respond to the action. Explicitly call respond to close the http
       // request before calling the users callback. If the user calls msg.respond() it will use the response_url
       // from the body of the request.
-      msg.respond({})
+      msg.clearResponse({ close: true })
       callback(msg, msg.body.message)
       return true
     }

--- a/test/slapp.test.js
+++ b/test/slapp.test.js
@@ -608,7 +608,7 @@ test.cb('Slapp.action() w/ selected_options', t => {
     .action(message.body.callback_id, /^beep.*/, /B[o]{2}p/, (msg, val) => {
       t.deepEqual(msg, message)
       t.true(Array.isArray(val))
-      t.same(val, ['no match', 'Boop'])
+      t.deepEqual(val, ['no match', 'Boop'])
     })
     ._handle(message, (err, handled) => {
       t.is(err, null)
@@ -719,7 +719,9 @@ test.cb('Slapp.messageAction() w/ no match on callback_id', t => {
   }, meta)
 
   app
-    .messageAction('no_match', (msg, messageParsed) => { })
+    .messageAction('no_match', (msg, messageParsed) => {
+      t.fail('messageAction should not be called when no match')
+    })
     ._handle(message, (err, handled) => {
       t.is(err, null)
       t.false(handled)
@@ -728,7 +730,7 @@ test.cb('Slapp.messageAction() w/ no match on callback_id', t => {
 })
 
 test.cb('Slapp.messageAction() w/ match', t => {
-  t.plan(3)
+  t.plan(4)
 
   let app = new Slapp({ context })
   let message = new Message('action', {
@@ -738,9 +740,11 @@ test.cb('Slapp.messageAction() w/ match', t => {
       ts: 'ts'
     }
   }, meta)
+  let clearSpy = sinon.stub(message, 'clearResponse')
 
   app
     .messageAction(message.body.callback_id, (msg, messageParsed) => {
+      t.true(clearSpy.called)
       t.deepEqual(message.body.message, messageParsed)
     })
     ._handle(message, (err, handled) => {


### PR DESCRIPTION
Be more explicit in the `messageAction` handler and call `msg.clearResponse({ close: true })` explicitly rather than `msg.respond({})`.

Hopefully fixes  https://github.com/MissionsAI/slapp/issues/106