### PR TITLE
message_action should close response immediately

### DIFF
--- a/src/receiver/middleware/parse-action.js
+++ b/src/receiver/middleware/parse-action.js
@@ -27,10 +27,14 @@ module.exports = () => {
           user_id: body.user.id,
           channel_id: body.channel.id,
           team_id: body.team.id
-        },
-        // Message actions may be responded to directly within 3000ms
-        response: res,
-        responseTimeout: 2500
+        }
+      }
+
+      // message_action's do not support returning a message in the HTTP response
+      if (body.type !== 'message_action') {
+        // May be responded to directly within 3000ms
+        req.slapp.response = res
+        req.slapp.responseTimeout = 2500
       }
 
       next()

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -789,11 +789,6 @@ class Slapp extends EventEmitter {
     let fn = (msg) => {
       if (msg.type !== 'action' || msg.body.type !== 'message_action') return
       if (msg.body.callback_id !== callbackId) return
-      // The message action requires a successful http response but you cannot send back a message response.
-      // Instead you use the response_url to respond to the action. Explicitly call respond to close the http
-      // request before calling the users callback. If the user calls msg.respond() it will use the response_url
-      // from the body of the request.
-      msg.clearResponse({ close: true })
       callback(msg, msg.body.message)
       return true
     }

--- a/test/middleware.parse-action.test.js
+++ b/test/middleware.parse-action.test.js
@@ -54,6 +54,25 @@ test.cb('ParseAction() valid payload', t => {
   })
 })
 
+test.cb('ParseAction() message_action valid payload', t => {
+  t.plan(3)
+  let mw = ParseAction().pop()
+
+  let payload = mockPayload()
+  payload.type = 'message_action'
+
+  let req = { body: { payload: JSON.stringify(payload) } }
+  let res = fixtures.getMockRes()
+
+  mw(req, res, () => {
+    let slapp = req.slapp
+    t.is(slapp.body.type, 'message_action')
+    t.deepEqual(slapp.body, payload)
+    t.falsy(slapp.response, 'response should be undefined if message_action')
+    t.end()
+  })
+})
+
 function mockPayload () {
   return {
     token: 'token',

--- a/test/slapp.test.js
+++ b/test/slapp.test.js
@@ -730,7 +730,7 @@ test.cb('Slapp.messageAction() w/ no match on callback_id', t => {
 })
 
 test.cb('Slapp.messageAction() w/ match', t => {
-  t.plan(4)
+  t.plan(3)
 
   let app = new Slapp({ context })
   let message = new Message('action', {
@@ -740,11 +740,9 @@ test.cb('Slapp.messageAction() w/ match', t => {
       ts: 'ts'
     }
   }, meta)
-  let clearSpy = sinon.stub(message, 'clearResponse')
 
   app
     .messageAction(message.body.callback_id, (msg, messageParsed) => {
-      t.true(clearSpy.called)
       t.deepEqual(message.body.message, messageParsed)
     })
     ._handle(message, (err, handled) => {


### PR DESCRIPTION
Moved the logic to close a response for `message_action` `action` requests into the receiver. Added a new test, cleaned up existing.

Fixes https://github.com/MissionsAI/slapp/issues/106