### PR TITLE
Adding support for verifying signature of requests via signed_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ The `msg` is the same as the Message type. `opts` includes the `opts.colors` pas
   
   Parameters
   - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
+  - `opts.signing_secret` Slack signing secret to check/verify the signature of requests coming from Slack
+  - `opts.signing_version` Slack signing version string, defaults to 'v0'
   - `opts.convo_store` Implementation of ConversationStore, defaults to memory
   - `opts.context` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with context
   - `opts.log` defaults to `true`, `false` to disable logging

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const Slapp = require('./slapp')
  * Parameters
  * - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
  * - `opts.signing_secret` Slack signing secret to check/verify the signature of requests coming from Slack
+ * - `opts.signing_version` Slack signing version string, defaults to 'v0'
  * - `opts.convo_store` Implementation of ConversationStore, defaults to memory
  * - `opts.context` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with context
  * - `opts.log` defaults to `true`, `false` to disable logging

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const Slapp = require('./slapp')
  *
  * Parameters
  * - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
+ * - `opts.signing_secret` Slack signing secret to check/verify the signature of requests coming from Slack
  * - `opts.convo_store` Implementation of ConversationStore, defaults to memory
  * - `opts.context` `Function (req, res, next)` HTTP Middleware function to enrich incoming request with context
  * - `opts.log` defaults to `true`, `false` to disable logging

--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -8,6 +8,7 @@ const ParseCommand = require('./middleware/parse-command')
 const ParseAction = require('./middleware/parse-action')
 const ParseOptions = require('./middleware/parse-options')
 const VerifyToken = require('./middleware/verify-token')
+const CheckSignature = require('./middleware/check-signature')
 const SSLCheck = require('./middleware/ssl-check')
 
 /**
@@ -20,6 +21,7 @@ module.exports = class Receiver extends EventEmitter {
     opts = opts || {}
 
     this.verify_token = opts.verify_token
+    this.signing_secret = opts.signing_secret
     this.context = opts.context
 
     // record all events to a JSON line delimited file if record is set
@@ -51,6 +53,7 @@ module.exports = class Receiver extends EventEmitter {
 
     let emitHandler = this.emitHandler.bind(this)
     let verifyToken = VerifyToken(this.verify_token, this.emit.bind(this, 'error'))
+    let checkSignature = CheckSignature(this.signing_secret, this.emit.bind(this, 'error'))
     let sslCheck = SSLCheck()
 
     if (options.event) {
@@ -58,6 +61,7 @@ module.exports = class Receiver extends EventEmitter {
         ParseEvent(),
         sslCheck,
         verifyToken,
+        checkSignature,
         this.context,
         emitHandler
       )
@@ -68,6 +72,7 @@ module.exports = class Receiver extends EventEmitter {
         ParseCommand(),
         sslCheck,
         verifyToken,
+        checkSignature,
         this.context,
         emitHandler
       )
@@ -78,6 +83,7 @@ module.exports = class Receiver extends EventEmitter {
         ParseAction(),
         sslCheck,
         verifyToken,
+        checkSignature,
         this.context,
         emitHandler
       )
@@ -88,6 +94,7 @@ module.exports = class Receiver extends EventEmitter {
         ParseOptions(),
         sslCheck,
         verifyToken,
+        checkSignature,
         this.context,
         emitHandler
       )

--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -22,6 +22,7 @@ module.exports = class Receiver extends EventEmitter {
 
     this.verify_token = opts.verify_token
     this.signing_secret = opts.signing_secret
+    this.signing_version = opts.signing_version
     this.context = opts.context
 
     // record all events to a JSON line delimited file if record is set
@@ -53,7 +54,7 @@ module.exports = class Receiver extends EventEmitter {
 
     let emitHandler = this.emitHandler.bind(this)
     let verifyToken = VerifyToken(this.verify_token, this.emit.bind(this, 'error'))
-    let checkSignature = CheckSignature(this.signing_secret, this.emit.bind(this, 'error'))
+    let checkSignature = CheckSignature(this.signing_secret, this.signing_version, this.emit.bind(this, 'error'))
     let sslCheck = SSLCheck()
 
     if (options.event) {

--- a/src/receiver/index.js
+++ b/src/receiver/index.js
@@ -52,52 +52,39 @@ module.exports = class Receiver extends EventEmitter {
       options[type] = options[type] === true ? defaults[type] : options[type]
     })
 
-    let emitHandler = this.emitHandler.bind(this)
-    let verifyToken = VerifyToken(this.verify_token, this.emit.bind(this, 'error'))
-    let checkSignature = CheckSignature(this.signing_secret, this.signing_version, this.emit.bind(this, 'error'))
-    let sslCheck = SSLCheck()
+    let defaultMiddlware = [
+      SSLCheck(),
+      VerifyToken(this.verify_token, this.emit.bind(this, 'error')),
+      CheckSignature(this.signing_secret, this.signing_version, this.emit.bind(this, 'error')),
+      this.context,
+      this.emitHandler.bind(this)
+    ]
 
     if (options.event) {
       app.post(options.event,
         ParseEvent(),
-        sslCheck,
-        verifyToken,
-        checkSignature,
-        this.context,
-        emitHandler
+        ...defaultMiddlware
       )
     }
 
     if (options.command) {
       app.post(options.command,
         ParseCommand(),
-        sslCheck,
-        verifyToken,
-        checkSignature,
-        this.context,
-        emitHandler
+        ...defaultMiddlware
       )
     }
 
     if (options.action) {
       app.post(options.action,
         ParseAction(),
-        sslCheck,
-        verifyToken,
-        checkSignature,
-        this.context,
-        emitHandler
+        ...defaultMiddlware
       )
     }
 
     if (options.options) {
       app.post(options.options,
         ParseOptions(),
-        sslCheck,
-        verifyToken,
-        checkSignature,
-        this.context,
-        emitHandler
+        ...defaultMiddlware
       )
     }
 

--- a/src/receiver/middleware/body-parser-verify.js
+++ b/src/receiver/middleware/body-parser-verify.js
@@ -1,0 +1,6 @@
+
+// The purpose of this middleware is to hook into the body-parser verify step
+// to capture the raw request body so it can be used later to check the signature
+module.exports = function verify (req, res, buffer, encoding) {
+  req.rawBody = buffer.toString()
+}

--- a/src/receiver/middleware/check-signature.js
+++ b/src/receiver/middleware/check-signature.js
@@ -1,9 +1,7 @@
 'use strict'
 const crypto = require('crypto')
 
-const VERSION = 'v0'
-
-module.exports = (secret, onError) => {
+module.exports = (secret, version = 'v0', onError) => {
   function invalidSignature (res) {
     if (onError) {
       onError('Invalid signature')
@@ -42,11 +40,11 @@ module.exports = (secret, onError) => {
       return null
     }
 
-    let basestring = `${VERSION}:${timestamp}:${rawBody}`
+    let basestring = `${version}:${timestamp}:${rawBody}`
     let digest = crypto.createHmac('sha256', secret)
       .update(basestring)
       .digest('hex')
-    return `${VERSION}=${digest}`
+    return `${version}=${digest}`
   }
 
   return checkSignatureMiddleware

--- a/src/receiver/middleware/check-signature.js
+++ b/src/receiver/middleware/check-signature.js
@@ -1,0 +1,53 @@
+'use strict'
+const crypto = require('crypto')
+
+const VERSION = 'v0'
+
+module.exports = (secret, onError) => {
+  function invalidSignature (res) {
+    if (onError) {
+      onError('Invalid signature')
+    }
+    res.status(403).send('Invalid signature')
+  }
+
+  function checkSignatureMiddleware (req, res, next) {
+    // If secret isn't set, we're not checking signature
+    if (!secret) {
+      return next()
+    }
+
+    let rawBody = req.rawBody
+    let message = req.slapp
+    let signature = message && message.meta && message.meta.signature
+    let timestamp = message && message.meta && message.meta.timestamp
+
+    if (!signature || !timestamp || !rawBody) {
+      return invalidSignature(res)
+    }
+
+    // Verify request signature matches
+    let computedSignature = checkSignatureMiddleware.compute(timestamp, rawBody)
+
+    if (computedSignature !== signature) {
+      return invalidSignature(res)
+    }
+
+    next()
+  }
+
+  // Expose this on mw instance for tests or manual computation if needed externally
+  checkSignatureMiddleware.compute = function (timestamp, rawBody) {
+    if (!secret) {
+      return null
+    }
+
+    let basestring = `${VERSION}:${timestamp}:${rawBody}`
+    let digest = crypto.createHmac('sha256', secret)
+      .update(basestring)
+      .digest('hex')
+    return `${VERSION}=${digest}`
+  }
+
+  return checkSignatureMiddleware
+}

--- a/src/receiver/middleware/check-signature.js
+++ b/src/receiver/middleware/check-signature.js
@@ -1,7 +1,12 @@
 'use strict'
 const crypto = require('crypto')
 
-module.exports = (secret, version = 'v0', onError) => {
+module.exports = (secret, version, onError) => {
+  // If secret is set, but no version is set, this is an error, version must be provided
+  if (secret && (!version || typeof version !== 'string')) {
+    throw new Error('Slack signing secret provided, but no version is provided')
+  }
+
   function invalidSignature (res) {
     if (onError) {
       onError('Invalid signature')

--- a/src/receiver/middleware/parse-action.js
+++ b/src/receiver/middleware/parse-action.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const bodyParser = require('body-parser')
+const verify = require('./body-parser-verify')
 
 module.exports = () => {
   return [
-    bodyParser.urlencoded({extended: true}),
+    bodyParser.urlencoded({ extended: true, verify: verify }),
     bodyParser.text({type: '*/*'}),
     function parseAction (req, res, next) {
       let body = req.body
@@ -24,6 +25,8 @@ module.exports = () => {
         body: body,
         meta: {
           verify_token: body.token,
+          signature: (req.headers || {})['x-slack-signature'],
+          timestamp: (req.headers || {})['x-slack-request-timestamp'],
           user_id: body.user.id,
           channel_id: body.channel.id,
           team_id: body.team.id

--- a/src/receiver/middleware/parse-command.js
+++ b/src/receiver/middleware/parse-command.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const bodyParser = require('body-parser')
+const verify = require('./body-parser-verify')
 
 module.exports = () => {
   return [
-    bodyParser.urlencoded({extended: true}),
+    bodyParser.urlencoded({ extended: true, verify: verify }),
     function parseCommand (req, res, next) {
       let body = req.body
 
@@ -13,6 +14,8 @@ module.exports = () => {
         body: body,
         meta: {
           verify_token: body.token,
+          signature: (req.headers || {})['x-slack-signature'],
+          timestamp: (req.headers || {})['x-slack-request-timestamp'],
           user_id: body.user_id,
           channel_id: body.channel_id,
           team_id: body.team_id

--- a/src/receiver/middleware/parse-event.js
+++ b/src/receiver/middleware/parse-event.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const bodyParser = require('body-parser')
+const verify = require('./body-parser-verify')
 
 module.exports = () => {
   return [
-    bodyParser.json(),
+    bodyParser.json({ verify: verify }),
     function handleChallenge (req, res, next) {
       let body = req.body || {}
 
@@ -27,12 +28,13 @@ module.exports = () => {
       } else if (!!event.user && typeof event.user === 'object') {
         userId = event.user.id
       }
-
       req.slapp = {
         type: 'event',
         body: body,
         meta: {
           verify_token: body.token,
+          signature: (req.headers || {})['x-slack-signature'],
+          timestamp: (req.headers || {})['x-slack-request-timestamp'],
           user_id: userId,
           bot_id: event.bot_id,
           channel_id: channelId,

--- a/src/receiver/middleware/parse-options.js
+++ b/src/receiver/middleware/parse-options.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const bodyParser = require('body-parser')
+const verify = require('./body-parser-verify')
 
 module.exports = () => {
   return [
-    bodyParser.urlencoded({extended: true}),
+    bodyParser.urlencoded({ extended: true, verify: verify }),
     function parseOptions (req, res, next) {
       let body = req.body
 
@@ -23,6 +24,8 @@ module.exports = () => {
         body: body,
         meta: {
           verify_token: body.token,
+          signature: (req.headers || {})['x-slack-signature'],
+          timestamp: (req.headers || {})['x-slack-request-timestamp'],
           user_id: body.user && body.user.id,
           channel_id: body.channel && body.channel.id,
           team_id: body.team && body.team.id

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -21,6 +21,7 @@ class Slapp extends EventEmitter {
    *
    * ##### Parameters
    * - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
+   * - `opts.signing_secret` Slack signing secret to check/verify the signature of requests coming from Slack
    * - `opts.convo_store` Implementation of ConversationStore, defaults to memory
    * - `opts.context` `Function (req, res, next)` Required HTTP Middleware function to enrich incoming request with context
    * - `opts.log` defaults to `true`, `false` to disable logging
@@ -40,6 +41,7 @@ class Slapp extends EventEmitter {
     super()
     opts = deap.update({
       verify_token: process.env.SLACK_VERIFY_TOKEN,
+      signing_secret: null,
       convo_store: null,
       context: null,
       log: true,

--- a/src/slapp.js
+++ b/src/slapp.js
@@ -22,6 +22,7 @@ class Slapp extends EventEmitter {
    * ##### Parameters
    * - `opts.verify_token` Slack Veryify token to validate authenticity of requests coming from Slack
    * - `opts.signing_secret` Slack signing secret to check/verify the signature of requests coming from Slack
+   * - `opts.signing_version` Slack signing version string, defaults to 'v0'
    * - `opts.convo_store` Implementation of ConversationStore, defaults to memory
    * - `opts.context` `Function (req, res, next)` Required HTTP Middleware function to enrich incoming request with context
    * - `opts.log` defaults to `true`, `false` to disable logging
@@ -42,6 +43,7 @@ class Slapp extends EventEmitter {
     opts = deap.update({
       verify_token: process.env.SLACK_VERIFY_TOKEN,
       signing_secret: null,
+      signing_version: 'v0',
       convo_store: null,
       context: null,
       log: true,

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -3,6 +3,7 @@
 exports.getMockReq = function (req) {
   return Object.assign({
     body: {},
+    headers: {},
     slapp: {
       meta: {}
     }
@@ -28,4 +29,11 @@ exports.getMockHeaders = function (headers) {
     'bb-slackteamname': 'slackteamname',
     'bb-slackteamdomain': 'slackteamdomain'
   }, headers || {})
+}
+
+exports.getMockSlackHeaders = function (signature, timestamp) {
+  return {
+    'x-slack-signature': signature,
+    'x-slack-request-timestamp': timestamp
+  }
 }

--- a/test/middleware.body-parser-verify.test.js
+++ b/test/middleware.body-parser-verify.test.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const test = require('ava').test
+const Verify = require('../src/receiver/middleware/body-parser-verify')
+
+test('CheckSignature() signing_secret option no signature or timestamp header', t => {
+  let rawBody = 'thisisjustarequestbody'
+  let req = {}
+  let buffer = new Buffer(rawBody)
+
+  Verify(req, {}, buffer)
+  t.is(req.rawBody, rawBody)
+})

--- a/test/middleware.check-signature.test.js
+++ b/test/middleware.check-signature.test.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const test = require('ava').test
+const sinon = require('sinon')
+const fixtures = require('./fixtures/')
+const CheckSignature = require('../src/receiver/middleware/check-signature')
+const SECRET = 'shhhhsecret'
+
+test.cb('CheckSignature() no signing_secret option', t => {
+  let mw = CheckSignature()
+
+  mw(getSignedRequest(mw), fixtures.getMockRes(), () => {
+    t.pass()
+    t.end()
+  })
+})
+
+test('CheckSignature() signing_secret option no signature or timestamp header', t => {
+  let mw = CheckSignature(SECRET)
+  let res = fixtures.getMockRes()
+
+  let statusStub = sinon.stub(res, 'status', () => { return res })
+  let sendStub = sinon.stub(res, 'send')
+
+  mw(getSignedRequest(mw, { signature: false, timestamp: false }), res, () => {})
+  t.true(statusStub.calledWith(403))
+  t.true(sendStub.calledWith('Invalid signature'))
+})
+
+test.cb('CheckSignature() signing_secret option no signature or timestamp header w/ error callback', t => {
+  let mw = CheckSignature(SECRET, (err) => {
+    t.is(err, 'Invalid signature')
+    t.pass()
+    t.end()
+  })
+  let res = fixtures.getMockRes()
+
+  let statusStub = sinon.stub(res, 'status', () => { return res })
+  let sendStub = sinon.stub(res, 'send')
+
+  mw(getSignedRequest(mw, { signature: false, timestamp: false }), res, () => { })
+  t.true(statusStub.calledWith(403))
+  t.true(sendStub.calledWith('Invalid signature'))
+})
+
+test('CheckSignature() signing_secret option w/ signature no timestamp header', t => {
+  let mw = CheckSignature(SECRET)
+  let res = fixtures.getMockRes()
+
+  let statusStub = sinon.stub(res, 'status', () => { return res })
+  let sendStub = sinon.stub(res, 'send')
+
+  mw(getSignedRequest(mw, { timestamp: false }), res, () => { })
+  t.true(statusStub.calledWith(403))
+  t.true(sendStub.calledWith('Invalid signature'))
+})
+
+test('CheckSignature() signing_secret option no signature w/ timestamp header', t => {
+  let mw = CheckSignature(SECRET)
+  let res = fixtures.getMockRes()
+
+  let statusStub = sinon.stub(res, 'status', () => { return res })
+  let sendStub = sinon.stub(res, 'send')
+
+  mw(getSignedRequest(mw, { signature: false }), res, () => { })
+  t.true(statusStub.calledWith(403))
+  t.true(sendStub.calledWith('Invalid signature'))
+})
+
+test.cb('CheckSignature() signing_secret option w/ valid signature', t => {
+  let mw = CheckSignature(SECRET, (err) => {
+    t.fail(err)
+    t.end()
+  })
+  let res = fixtures.getMockRes()
+
+  mw(getSignedRequest(mw, {}), res, () => {
+    t.pass()
+    t.end()
+  })
+})
+
+test('CheckSignature() signing_secret option w/ invalid signature', t => {
+  let mw = CheckSignature(SECRET)
+  let res = fixtures.getMockRes()
+
+  let statusStub = sinon.stub(res, 'status', () => { return res })
+  let sendStub = sinon.stub(res, 'send')
+
+  mw(getSignedRequest(mw, {}, false), res, () => { })
+  t.true(statusStub.calledWith(403))
+  t.true(sendStub.calledWith('Invalid signature'))
+})
+
+function getSignedRequest (mw, { signature = true, timestamp = true } = {}, validSignature = true) {
+  let rawBody = 'thisisjustatestbody'
+  let currentTimestamp = Date.now()
+  let computedSignature = validSignature
+    ? mw.compute(currentTimestamp, rawBody)
+    : 'thisisaninvalidsignature'
+
+  return fixtures.getMockReq({
+    rawBody,
+    slapp: {
+      meta: {
+        signature: signature ? computedSignature : undefined,
+        timestamp: timestamp ? currentTimestamp : undefined
+      }
+    }
+  })
+}

--- a/test/middleware.check-signature.test.js
+++ b/test/middleware.check-signature.test.js
@@ -5,6 +5,7 @@ const sinon = require('sinon')
 const fixtures = require('./fixtures/')
 const CheckSignature = require('../src/receiver/middleware/check-signature')
 const SECRET = 'shhhhsecret'
+const VERSION = 'v0'
 
 test.cb('CheckSignature() no signing_secret option', t => {
   let mw = CheckSignature()
@@ -28,7 +29,7 @@ test('CheckSignature() signing_secret option no signature or timestamp header', 
 })
 
 test.cb('CheckSignature() signing_secret option no signature or timestamp header w/ error callback', t => {
-  let mw = CheckSignature(SECRET, (err) => {
+  let mw = CheckSignature(SECRET, VERSION, (err) => {
     t.is(err, 'Invalid signature')
     t.pass()
     t.end()
@@ -68,7 +69,7 @@ test('CheckSignature() signing_secret option no signature w/ timestamp header', 
 })
 
 test.cb('CheckSignature() signing_secret option w/ valid signature', t => {
-  let mw = CheckSignature(SECRET, (err) => {
+  let mw = CheckSignature(SECRET, VERSION, (err) => {
     t.fail(err)
     t.end()
   })

--- a/test/middleware.check-signature.test.js
+++ b/test/middleware.check-signature.test.js
@@ -17,7 +17,7 @@ test.cb('CheckSignature() no signing_secret option', t => {
 })
 
 test('CheckSignature() signing_secret option no signature or timestamp header', t => {
-  let mw = CheckSignature(SECRET)
+  let mw = CheckSignature(SECRET, VERSION)
   let res = fixtures.getMockRes()
 
   let statusStub = sinon.stub(res, 'status', () => { return res })
@@ -45,7 +45,7 @@ test.cb('CheckSignature() signing_secret option no signature or timestamp header
 })
 
 test('CheckSignature() signing_secret option w/ signature no timestamp header', t => {
-  let mw = CheckSignature(SECRET)
+  let mw = CheckSignature(SECRET, VERSION)
   let res = fixtures.getMockRes()
 
   let statusStub = sinon.stub(res, 'status', () => { return res })
@@ -57,7 +57,7 @@ test('CheckSignature() signing_secret option w/ signature no timestamp header', 
 })
 
 test('CheckSignature() signing_secret option no signature w/ timestamp header', t => {
-  let mw = CheckSignature(SECRET)
+  let mw = CheckSignature(SECRET, VERSION)
   let res = fixtures.getMockRes()
 
   let statusStub = sinon.stub(res, 'status', () => { return res })
@@ -82,7 +82,7 @@ test.cb('CheckSignature() signing_secret option w/ valid signature', t => {
 })
 
 test('CheckSignature() signing_secret option w/ invalid signature', t => {
-  let mw = CheckSignature(SECRET)
+  let mw = CheckSignature(SECRET, VERSION)
   let res = fixtures.getMockRes()
 
   let statusStub = sinon.stub(res, 'status', () => { return res })
@@ -91,6 +91,34 @@ test('CheckSignature() signing_secret option w/ invalid signature', t => {
   mw(getSignedRequest(mw, {}, false), res, () => { })
   t.true(statusStub.calledWith(403))
   t.true(sendStub.calledWith('Invalid signature'))
+})
+
+test.cb('CheckSignature() signing_secret option w/o version should throw', t => {
+  try {
+    CheckSignature(SECRET)
+  } catch (e) {
+    t.truthy(e)
+    t.is(e.message, 'Slack signing secret provided, but no version is provided')
+    t.pass()
+    t.end()
+    return
+  }
+
+  t.fail('Should not be able to create middleware function without a version when secret is provided')
+})
+
+test.cb('CheckSignature() signing_secret option w/ onError cb as version should throw', t => {
+  try {
+    CheckSignature(SECRET, () => {})
+  } catch (e) {
+    t.truthy(e)
+    t.is(e.message, 'Slack signing secret provided, but no version is provided')
+    t.pass()
+    t.end()
+    return
+  }
+
+  t.fail('Should not be able to create middleware function without a version string when secret is provided')
 })
 
 function getSignedRequest (mw, { signature = true, timestamp = true } = {}, validSignature = true) {

--- a/test/middleware.parse-action.test.js
+++ b/test/middleware.parse-action.test.js
@@ -5,6 +5,9 @@ const sinon = require('sinon')
 const fixtures = require('./fixtures/')
 const ParseAction = require('../src/receiver/middleware/parse-action')
 
+const SIGNATURE = 'mysignature'
+const TIMESTAMP = Date.now()
+
 test('ParseAction()', t => {
   let mw = ParseAction()
   t.is(mw.length, 3)
@@ -31,11 +34,14 @@ test('ParseAction() invalid json payload', t => {
 })
 
 test.cb('ParseAction() valid payload', t => {
-  t.plan(8)
+  t.plan(10)
   let mw = ParseAction().pop()
 
   let payload = mockPayload()
-  let req = { body: { payload: JSON.stringify(payload) } }
+  let req = {
+    body: { payload: JSON.stringify(payload) },
+    headers: fixtures.getMockSlackHeaders(SIGNATURE, TIMESTAMP)
+  }
   let res = fixtures.getMockRes()
 
   mw(req, res, () => {
@@ -47,6 +53,8 @@ test.cb('ParseAction() valid payload', t => {
     t.is(slapp.meta.user_id, payload.user.id)
     t.is(slapp.meta.channel_id, payload.channel.id)
     t.is(slapp.meta.team_id, payload.team.id)
+    t.is(slapp.meta.signature, SIGNATURE)
+    t.is(slapp.meta.timestamp, TIMESTAMP)
     t.is(slapp.response, res)
     t.is(slapp.responseTimeout, 2500)
 

--- a/test/middleware.parse-command.test.js
+++ b/test/middleware.parse-command.test.js
@@ -4,6 +4,9 @@ const test = require('ava').test
 const ParseCommand = require('../src/receiver/middleware/parse-command')
 const fixtures = require('./fixtures/')
 
+const SIGNATURE = 'mysignature'
+const TIMESTAMP = Date.now()
+
 test('ParseCommand()', t => {
   let mw = ParseCommand()
   t.is(mw.length, 2)
@@ -29,7 +32,10 @@ test.cb('ParseCommand() no payload', t => {
 test.cb('ParseCommand() with payload', t => {
   let mw = ParseCommand().pop()
   let payload = mockPayload()
-  let req = { body: payload }
+  let req = {
+    body: payload,
+    headers: fixtures.getMockSlackHeaders(SIGNATURE, TIMESTAMP)
+  }
   let res = fixtures.getMockRes()
 
   mw(req, res, () => {
@@ -41,6 +47,8 @@ test.cb('ParseCommand() with payload', t => {
     t.is(slapp.meta.user_id, payload.user_id)
     t.is(slapp.meta.channel_id, payload.channel_id)
     t.is(slapp.meta.team_id, payload.team_id)
+    t.is(slapp.meta.signature, SIGNATURE)
+    t.is(slapp.meta.timestamp, TIMESTAMP)
     t.is(slapp.response, res)
     t.is(slapp.responseTimeout, 2500)
     t.end()

--- a/test/middleware.parse-event.test.js
+++ b/test/middleware.parse-event.test.js
@@ -5,6 +5,9 @@ const sinon = require('sinon')
 const fixtures = require('./fixtures/')
 const ParseEvent = require('../src/receiver/middleware/parse-event')
 
+const SIGNATURE = 'mysignature'
+const TIMESTAMP = Date.now()
+
 test('ParseEvent()', t => {
   let mw = ParseEvent()
   t.is(mw.length, 3)
@@ -31,7 +34,10 @@ test.cb('ParseEvent() no payload', t => {
 test.cb('ParseEvent() with payload', t => {
   let mw = ParseEvent().pop()
   let payload = mockPayload()
-  let req = { body: payload }
+  let req = {
+    body: payload,
+    headers: fixtures.getMockSlackHeaders(SIGNATURE, TIMESTAMP)
+  }
 
   mw(req, {}, () => {
     let slapp = req.slapp
@@ -43,6 +49,8 @@ test.cb('ParseEvent() with payload', t => {
     t.is(slapp.meta.bot_id, payload.event.bot_id)
     t.is(slapp.meta.channel_id, payload.event.channel)
     t.is(slapp.meta.team_id, payload.team_id)
+    t.is(slapp.meta.signature, SIGNATURE)
+    t.is(slapp.meta.timestamp, TIMESTAMP)
     t.end()
   })
 })

--- a/test/middleware.parse-options.test.js
+++ b/test/middleware.parse-options.test.js
@@ -4,6 +4,9 @@ const test = require('ava').test
 const ParseOptions = require('../src/receiver/middleware/parse-options')
 const fixtures = require('./fixtures/')
 
+const SIGNATURE = 'mysignature'
+const TIMESTAMP = Date.now()
+
 test('ParseOptions()', t => {
   let mw = ParseOptions()
   t.is(mw.length, 2)
@@ -34,7 +37,10 @@ test.cb('ParseOptions() unparsable payload', t => {
 test.cb('ParseOptions() with payload', t => {
   let mw = ParseOptions().pop()
   let payload = mockPayload()
-  let req = { body: { payload: JSON.stringify(payload) } }
+  let req = {
+    body: { payload: JSON.stringify(payload) },
+    headers: fixtures.getMockSlackHeaders(SIGNATURE, TIMESTAMP)
+  }
   let res = fixtures.getMockRes()
 
   mw(req, res, (err) => {
@@ -47,6 +53,8 @@ test.cb('ParseOptions() with payload', t => {
     t.is(slapp.meta.user_id, payload.user.id)
     t.is(slapp.meta.channel_id, payload.channel.id)
     t.is(slapp.meta.team_id, payload.team.id)
+    t.is(slapp.meta.signature, SIGNATURE)
+    t.is(slapp.meta.timestamp, TIMESTAMP)
     t.is(slapp.response, res)
     t.is(slapp.responseTimeout, 3000)
     t.end()


### PR DESCRIPTION
This adds a new option when instantiating a `slapp()` instance - `signing_secret`.  
```js
slapp({ signing_secret: 'shhhh' })
```
If set, it will verify the incoming requests are signed appropriately from Slack [per their documentation](https://api.slack.com/docs/verifying-requests-from-slack).  If the option is not set, it won't attempt to verify the signature sent w/ the request.

**Discussion:**
Currently, part of the signature includes a version string, that Slack states is always going to be `v0` right now.  It's set in the code to a constant of `v0`.  It's not clear if this will later come as a header, or if it should be configurable on the slapp instance, via something like: 

```js
slapp({ signatureVersion: 'v0' })
```
Would appreciate feedback around this, am leaning towards just making it a config option.

Another point worth noting, in order to compute the signature, the raw request body is needed.  The easiest way I found to accomplish this was to tap into the `verify` callback that the existing `body-parser` middleware fns are using, and add a `rawBody` property to the request that is the string version of the request body buffer.
